### PR TITLE
Wip/gtk 3.12

### DIFF
--- a/gtk/torrent-cell-renderer.c
+++ b/gtk/torrent-cell-renderer.c
@@ -33,7 +33,7 @@ enum
 #define DEFAULT_BAR_HEIGHT 12
 #define SMALL_SCALE 0.9
 #define COMPACT_ICON_SIZE GTK_ICON_SIZE_MENU
-#define FULL_ICON_SIZE GTK_ICON_SIZE_DND
+#define FULL_ICON_SIZE GTK_ICON_SIZE_DIALOG
 
 /***
 ****
@@ -717,13 +717,13 @@ render_full (TorrentCellRenderer   * cell,
     fill_area.height -= ypad * 2;
 
     /* icon */
-    icon_area.x = fill_area.x;
+    icon_area.x = fill_area.x + GUI_PAD;
     icon_area.y = fill_area.y + (fill_area.height - icon_area.height) / 2;
 
     /* name */
-    name_area.x = icon_area.x + icon_area.width + GUI_PAD;
+    name_area.x = icon_area.x + icon_area.width + 2 * GUI_PAD;
     name_area.y = fill_area.y;
-    name_area.width = fill_area.width - GUI_PAD - icon_area.width - GUI_PAD_SMALL;
+    name_area.width = fill_area.width - 4 * GUI_PAD - icon_area.width - GUI_PAD_SMALL;
 
     /* prog */
     prog_area.x = name_area.x;

--- a/gtk/transmission-menus.ui
+++ b/gtk/transmission-menus.ui
@@ -25,18 +25,7 @@
         <attribute name="action">win.preferences</attribute>
       </item>
     </section>
-    
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">_Start All</attribute>
-        <attribute name="action">win.start-all-torrents</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">_Pause All</attribute>
-        <attribute name="action">win.pause-all-torrents</attribute>
-      </item>
-    </section>
-    
+
     <section>
       <item>
         <attribute name="label" translatable="yes">Message _Log</attribute>
@@ -57,13 +46,10 @@
         <attribute name="action">win.show-about-dialog</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">_Contents</attribute>
+        <attribute name="label" translatable="yes">_Help</attribute>
         <attribute name="action">win.help</attribute>
         <attribute name="accel">F1</attribute>
       </item>
-    </section>
-
-    <section>
       <item>
         <attribute name="label" translatable="yes">_Quit</attribute>
         <attribute name="action">win.quit</attribute>

--- a/gtk/transmission-menus.ui
+++ b/gtk/transmission-menus.ui
@@ -27,6 +27,17 @@
     </section>
 
     <section>
+        <item>
+            <attribute name="label" translatable="yes">_Start All</attribute>
+            <attribute name="action">win.start-all-torrents</attribute>
+        </item>
+        <item>
+            <attribute name="label" translatable="yes">_Pause All</attribute>
+            <attribute name="action">win.pause-all-torrents</attribute>
+        </item>
+    </section>
+
+    <section>
       <item>
         <attribute name="label" translatable="yes">Message _Log</attribute>
         <attribute name="action">win.toggle-message-log</attribute>


### PR DESCRIPTION
Appmenu changes:
- Renamed Contents to Help
- Moved Quit into the same section as Help and About

Statusbar changes:
- Moved upload and download speed labels from status bar to headerbar subtitle
- Removed Statistics label and button from the statusbar

Torrent rendering changes:
- In full mode increase the icon padding to better match the design
