### PR TITLE
Update autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,6 +24,7 @@ export LIBTOOLIZE
 
 ./update-version-h.sh
 
+rm m4/glib-gettext.m4
 autoreconf -fi || exit 1;
 
 


### PR DESCRIPTION
Fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=820785
As done here: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=c13b5e88c6e9c7bd2698d844cb5ed127ed809f7e

Otherwise can fail with: `FTBFS: m4/glib-gettext.m4:39: error: m4_copy: won't overwrite defined macro: glib_DEFUN` on new glibs.